### PR TITLE
Update postsSlice to track loading state

### DIFF
--- a/src/features/posts/postsSlice.js
+++ b/src/features/posts/postsSlice.js
@@ -1,24 +1,11 @@
 import { createSlice, nanoid } from "@reduxjs/toolkit" 
 import { sub } from 'date-fns'
 
-const initialState = [
-    { 
-        id: '1', 
-        title: 'First Post!', 
-        content: 'Hello!',
-        user: '1', 
-        date: sub(new Date(), { minutes: 10 }).toISOString(),
-        reactions: {thumbsUp: 0, hooray: 0, heart: 0, rocket: 0, eyes: 0}
-    },
-    { 
-        id: '2', 
-        title: 'Second Post', 
-        content: 'More text',
-        user: '2', 
-        date: sub(new Date(), { minutes: 5 }).toISOString(),
-        reactions: {thumbsUp: 0, hooray: 0, heart: 0, rocket: 0, eyes: 0}
-    }
-]
+const initialState = {
+    posts: [],
+    status: 'idle',
+    error: null
+}
 
 const postsSlice = createSlice({
     name: 'posts',
@@ -26,7 +13,7 @@ const postsSlice = createSlice({
     reducers: {
         postAdded: { 
             reducer(state, action) {
-                state.push(action.payload)
+                state.posts.push(action.payload)
             },
             prepare(title, content, userId, reactions) {
                 return {
@@ -43,7 +30,7 @@ const postsSlice = createSlice({
         },
         postUpdated(state, action) {
             const { id, title, content } = action.payload
-            const existingPost = state.find(post => post.id = id)
+            const existingPost = state.posts.find(post => post.id === id)
             if (existingPost) {
                 existingPost.title = title
                 existingPost.content = content
@@ -51,7 +38,7 @@ const postsSlice = createSlice({
         },
         reactionAdded(state, action) {
             const { postId, reaction } = action.payload
-            const existingPost = state.find(post => post.id === postId)
+            const existingPost = state.posts.find(post => post.id === postId)
             if (existingPost) {
                 existingPost.reactions[reaction]++
             }
@@ -63,9 +50,11 @@ export const { postAdded, postUpdated, reactionAdded } = postsSlice.actions;
 
 export default postsSlice.reducer;
 
-export const selectAllPosts = state => state.posts;
+export const selectAllPosts = state => state.posts.posts;
 
 export const selectPostById = (state, postId) => 
-    state.posts.find(post => post.id === postId)
+    state.posts.posts.find(post => post.id === postId)
+
+// It's often a good idea to encapsulate data lookups by writing reusable selectors but it's not something you should do all of the time.
 
 // .find returns undefined if not true


### PR DESCRIPTION
Edited postsSlice to track loading state for a "fetch posts" request. Switched the state from being an array of posts to look like {posts, status, error}. Finally, had to change any uses of **state** as an array to **state.posts** because the array is now one level deeper in initial state.