### PR TITLE
Define extraReducers for fetchPosts thunk

### DIFF
--- a/src/features/posts/postsSlice.js
+++ b/src/features/posts/postsSlice.js
@@ -50,6 +50,21 @@ const postsSlice = createSlice({
                 existingPost.reactions[reaction]++
             }
         }
+    },
+    extraReducers(builder) {
+        builder
+            .addCase(fetchPosts.pending, (state, action) => {
+                state.status = 'loading'
+            })
+            .addCase(fetchPosts.fulfilled, (state, action) => {
+                state.status = 'succeeded'
+                // Add any fetched  posts to the array
+                state.posts = state.posts.concat(action.payload)
+            })
+            .addCase(fetchPosts.rejected, (state, action) => {
+                state.status = 'failed'
+                state.error = action.error.message
+            })
     }
 })
 


### PR DESCRIPTION
Wrote extraReducers in createSlice in order to listen for the 'pending' and 'fulfilled' action types dispatched by the fetchPosts which are then passed to extraReducers to listen to those actions. 